### PR TITLE
hubot_user email_address replaced with name

### DIFF
--- a/src/nagios.coffee
+++ b/src/nagios.coffee
@@ -50,7 +50,7 @@ module.exports = (robot) ->
     res.end()
 
   robot.respond /nagios(NULL|(.*))/i, (msg) ->
-    hubot_user = msg['message']['user']['email_address']
+    hubot_user = msg['message']['user']['name']
     words = msg.match[1]
     input = words.split(' ');
     if words.length < 1


### PR DESCRIPTION
"hubot_user" used deprecated "email_address" property. Replaced with "name".